### PR TITLE
accept any android device name that isn't whitespace

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -77,7 +77,7 @@ impl PlatformManager for AndroidManager {
     fn devices(&self) -> Result<Vec<Box<Device>>> {
         let result = Command::new("adb").arg("devices").output()?;
         let mut devices = vec![];
-        let device_regex = ::regex::Regex::new(r#"^(\w+)\tdevice\r?$"#)?;
+        let device_regex = ::regex::Regex::new(r#"^(\S+)\tdevice\r?$"#)?;
         for line in String::from_utf8(result.stdout)?.split("\n").skip(1) {
             if let Some(caps) = device_regex.captures(line) {
                 let d = AndroidDevice::from_id(&caps[1])?;


### PR DESCRIPTION
when connected over tcpip the name is an ipaddress and port 192.168.1.104:5555 for example. This doesn't get picked up by the current regex