### PR TITLE
support more android architechtures

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -40,7 +40,13 @@ impl Device for AndroidDevice {
         &*self.id
     }
     fn target(&self) -> String {
-        self.supported_targets.get(0).unwrap_or(&"").to_string()
+        // Prefer arm-linux-androideabi if valid because it's Tier 1
+        self.supported_targets.iter()
+            .filter(|&s| s == &"arm-linux-androideabi")
+            .next()
+            .or_else(|| self.supported_targets.get(0))
+            .unwrap_or(&"")
+            .to_string()
     }
     fn can_run(&self, target: &str) -> bool {
         self.supported_targets.iter().any(|&t| t == target)

--- a/src/android.rs
+++ b/src/android.rs
@@ -28,7 +28,8 @@ impl Device for AndroidDevice {
         "arm-linux-androideabi".to_string()
     }
     fn can_run(&self, target: &str) -> bool {
-        target.ends_with("-linux-androideabi")
+        target.ends_with("-linux-androideabi") ||
+        target.ends_with("-linux-android")
     }
     fn start_remote_lldb(&self) -> Result<String> {
         unimplemented!()

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -89,12 +89,7 @@ fn guess_linker(device_target: &str) -> Result<Option<String>> {
             }
         }
 
-        let (toolchain, gcc, arch) = match device_target {
-            "armv7-linux-androideabi" => ("arm-linux-androideabi", "arm-linux-androideabi", "arch-arm"),
-            "aarch64-linux-android" => (device_target, device_target, "arch-arm64"),
-            "i686-linux-android" => ("x86", device_target, "arch-x86"),
-            _ => (device_target, device_target, "arch-arm"),
-        };
+        let (toolchain, gcc, arch) = ndk_details(device_target)?;
 
         let home = env::var("ANDROID_NDK_HOME")
                 .map_err(|_| "environment variable ANDROID_NDK_HOME is required")?;
@@ -126,14 +121,11 @@ fn guess_linker(device_target: &str) -> Result<Option<String>> {
 #[cfg(target_os="windows")]
 fn guess_linker(device_target: &str) -> Result<Option<String>> {
     if device_target.contains("-linux-android") {
-        let (toolchain, gcc, arch) = match device_target {
-            "armv7-linux-androideabi" => ("arm-linux-androideabi", "arm-linux-androideabi", "arch-arm"),
-            "aarch64-linux-android" => (device_target, device_target, "arch-arm64"),
-            "i686-linux-android" => ("x86", device_target, "arch-x86"),
-            _ => (device_target, device_target, "arch-arm"),
-        };
+        let (toolchain, gcc, arch) = ndk_details(device_target)?;
+
         let home = env::var("ANDROID_NDK_HOME")
                 .map_err(|_| "environment variable ANDROID_NDK_HOME is required")?;
+                
         let api = env::var("ANDROID_API")
                 .unwrap_or(default_api_for_arch(arch)?.into());
 
@@ -157,6 +149,16 @@ fn guess_linker(device_target: &str) -> Result<Option<String>> {
     } else {
         Ok(None)
     }
+}
+
+fn ndk_details(rust_target: &str) -> Result<(&str, &str, &str)>{
+    Ok(
+        match rust_target {
+            "armv7-linux-androideabi" => ("arm-linux-androideabi", "arm-linux-androideabi", "arch-arm"),
+            "aarch64-linux-android" => (rust_target, rust_target, "arch-arm64"),
+            "i686-linux-android" => ("x86", rust_target, "arch-x86"),
+            _ => (rust_target, rust_target, "arch-arm"),
+    })
 }
 
 fn default_api_for_arch(android_arch: &str) -> Result<&'static str> {

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -100,7 +100,8 @@ fn guess_linker(device_target: &str) -> Result<Option<String>> {
         let prebuilt_dir = format!(r"{home}/toolchains/{toolchain}-4.9/prebuilt",
             home = home, toolchain = toolchain);
 
-        let prebuilt = fs::read_dir(path::Path::new(&prebuilt_dir))?
+        let prebuilt = fs::read_dir(&prebuilt_dir)
+            .map_err(|e| format!("Error finding prebuilt {}: {}", prebuilt_dir, e))?
             .next()
             .ok_or("No prebuilt toolchain in your android setup")??;
 

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -104,10 +104,11 @@ fn guess_linker(device_target: &str) -> Result<Option<String>> {
 #[cfg(target_os="windows")]
 fn guess_linker(device_target: &str) -> Result<Option<String>> {
     if device_target.contains("-linux-android") {
-        let (toolchain, arch) = match device_target {
-            "armv7-linux-androideabi" => ("arm-linux-androideabi", "arm"),
-            "aarch64-linux-android" => (device_target, "arm64"),
-            _ => (device_target, "arm"),
+        let (toolchain, gcc, arch) = match device_target {
+            "armv7-linux-androideabi" => ("arm-linux-androideabi", "arm-linux-androideabi", "arm"),
+            "aarch64-linux-android" => (device_target, device_target, "arm64"),            
+            "i686-linux-android" => ("x86", device_target, "x86"),
+            _ => (device_target, device_target, "arm"),
         };
         let home = env::var("ANDROID_NDK_HOME")
                 .map_err(|_| "environment variable ANDROID_NDK_HOME is required")?;
@@ -125,9 +126,9 @@ fn guess_linker(device_target: &str) -> Result<Option<String>> {
             toolchain_bin = prebuilt_dir + r"\windows\bin";
         }
 
-        Ok(Some(format!(r"{toolchain_bin}\{toolchain}-gcc --sysroot {home}\platforms\{api}\arch-{arch} %* ",
+        Ok(Some(format!(r"{toolchain_bin}\{gcc}-gcc --sysroot {home}\platforms\{api}\arch-{arch} %* ",
             toolchain_bin = toolchain_bin,
-            toolchain = toolchain,
+            gcc = gcc,
             home = home,
             api = api,
             arch = arch)))

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -39,9 +39,6 @@ fn create_shim<P: AsRef<path::Path>>(root: P,
     let target_path = root.as_ref().join("target").join(device_target);
     fs::create_dir_all(&target_path)?;
     let shim = target_path.join("linker");
-    if shim.exists() {
-        return Ok(shim);
-    }
     let mut linker_shim = fs::File::create(&shim)?;
     writeln!(linker_shim, "#!/bin/sh")?;
     linker_shim.write_all(shell.as_bytes())?;


### PR DESCRIPTION
i wanted to run aarch64 tests on my phone, and x86 tests on the emulator so i fixed this 👍  have tested it on windows and macos

- detect and accept targets that are valid for the device
- prefer arm-linux-androideabi if valid (because it's tier1)
- fix copying of sources and test data to device
- general tidying in android.rs / linker.rs
- you can override api level with `$ANDROID_API`