### PR TITLE
Allow copy_git_ignored to be added to test data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = [ "development-tools::cargo-plugins", "development-tools::testing" 
 travis-ci = { repository = "snipsco/dinghy" }
 
 [dependencies]
-error-chain = "0.5"
+error-chain = "0.10"
 libc="0.2"
 tempfile = "2.1"
 tempdir = "0.3"
@@ -28,9 +28,9 @@ plist = "0.0.14"
 regex = "0.1"
 json = "0.11"
 ignore = "0.1"
-serde = "0.8"
-serde_derive = "0.8"
-toml = { version = "0.2", features = [ "serde" ] }
+serde = "1.0.8"
+serde_derive = "1.0.8"
+toml = { version = "0.4.2", features = [ "serde" ] }
 
 [target.'cfg(target_os="macos")'.dependencies]
 core-foundation = "0.2"

--- a/README.md
+++ b/README.md
@@ -258,6 +258,16 @@ conf_file = "/etc/some/file"
 The keys are the name under which to look for files below "test_data" in the
 bundles, and the values are what to be copied (from your development workstation).
 
+By default anything in `.gitignore` or `.dinghyignore` is not copied, however if
+you need .gitignore'd files to be copied it can be excluded by adding
+`copy_git_ignored = true`:
+
+```toml
+[test_data]
+the_data = { source = "../data-2017-02-05", copy_git_ignored = true }
+conf_file = "/etc/some/file"
+```
+
 Once again, you'll need to go through an helper in your code. Something like
 that should do:
 

--- a/src/android.rs
+++ b/src/android.rs
@@ -72,7 +72,7 @@ impl Device for AndroidDevice {
         fs::copy(&exe, &bundled_exe_path)?;
 
         debug!("Copying src to bundle");
-        ::rec_copy(source, &bundle_path.join("src"))?;
+        ::rec_copy(source, &bundle_path.join("src"), false)?;
 
         debug!("Copying test_data to bundle");
         ::copy_test_data(source, &bundle_path)?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,13 +1,13 @@
-error_chain!{
+error_chain! {
     foreign_links {
-        ::std::io::Error, IoError;
-        ::std::string::FromUtf8Error, StringFromUtf8Error;
-        ::std::path::StripPrefixError, PathStripPrefixError;
-        Box<::cargo::CargoError>, CargoError;
-        ::plist::Error, PlistError;
-        ::regex::Error, RegexError;
-        ::json::Error, JsonError;
-        ::ignore::Error, IgnoreError;
-        ::toml::DecodeError, TomlDecodeError;
+        IoError(::std::io::Error);
+        StringFromUtf8Error(::std::string::FromUtf8Error);
+        PathStripPrefixError(::std::path::StripPrefixError);
+        CargoError(Box<::cargo::CargoError>);
+        PlistError(::plist::Error);
+        RegexError(::regex::Error);
+        JsonError(::json::Error);
+        IgnoreError(::ignore::Error);
+        TomlDecodeError(::toml::de::Error);
     }
 }

--- a/src/ios/xcode.rs
+++ b/src/ios/xcode.rs
@@ -36,7 +36,7 @@ pub fn wrap_as_app<P1, P2, P3>(target: &str,
              target.split("-").next().unwrap())?;
     writeln!(plist, r#"</dict></plist>"#)?;
 
-    ::rec_copy(&source, app_path.join("src"))?;
+    ::rec_copy(&source, app_path.join("src"), false)?;
     ::copy_test_data(source, &app_path)?;
     Ok(app_path)
 }

--- a/test-ws/test-app/.dinghy.toml
+++ b/test-ws/test-app/.dinghy.toml
@@ -1,3 +1,3 @@
 [test_data]
 dinghy_source = "../.."
-dinghy_license = "../../LICENSE"
+dinghy_license = { source = "../../LICENSE", copy_git_ignored = true }


### PR DESCRIPTION
Allows files in .gitignore to be copied as test data.

See #24 