### PR TITLE
Implement clean_app in ssh, add path and port options

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -88,6 +88,8 @@ pub struct SshDeviceConfiguration {
     pub hostname: String,
     pub username: String,
     pub target: String,
+    pub port: Option<u16>,
+    pub path: Option<String>,
 }
 
 impl Configuration {

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -29,18 +29,31 @@ impl Device for SshDevice {
     fn install_app(&self, app: &path::Path) -> Result<()> {
         let user_at_host = format!("{}@{}", self.config.username, self.config.hostname);
         let prefix = self.config.path.clone().unwrap_or("/tmp".into());
-        let _stat = process::Command::new("ssh")
-            .args(
-                &[
-                    &*user_at_host,
-                    "-p",
-                    &*format!("{}", self.config.port.unwrap_or(22)),
-                    "mkdir",
-                    "-p",
-                    &*format!("{}/dinghy", prefix),
-                ],
-            )
-            .status();
+        let _stat = if let Some(port) = self.config.port {
+            process::Command::new("ssh")
+                .args(
+                    &[
+                        &*user_at_host,
+                        "-p",
+                        &*format!("{}", port),
+                        "mkdir",
+                        "-p",
+                        &*format!("{}/dinghy", prefix),
+                    ],
+                )
+                .status()
+        } else {
+            process::Command::new("ssh")
+                .args(
+                    &[
+                        &*user_at_host,
+                        "mkdir",
+                        "-p",
+                        &*format!("{}/dinghy", prefix),
+                    ],
+                )
+                .status()
+        };
         let target_path = format!(
             "{}/dinghy/{}",
             prefix,
@@ -53,14 +66,23 @@ impl Device for SshDevice {
             user_at_host,
             &*target_path
         );
-        let stat = process::Command::new("/usr/bin/rsync")
-            .arg("-a")
-            .arg("-v")
-            .arg("-e")
-            .arg(&*format!("ssh -p {}", self.config.port.unwrap_or(22)))
-            .arg(&*format!("{}/", app.to_str().unwrap()))
-            .arg(&*format!("{}:{}/", user_at_host, &*target_path))
-            .status()?;
+        let stat = if let Some(port) = self.config.port {
+            process::Command::new("/usr/bin/rsync")
+                .arg("-a")
+                .arg("-v")
+                .arg("-e")
+                .arg(&*format!("ssh -p {}", port))
+                .arg(&*format!("{}/", app.to_str().unwrap()))
+                .arg(&*format!("{}:{}/", user_at_host, &*target_path))
+                .status()?
+        } else {
+            process::Command::new("/usr/bin/rsync")
+                .arg("-a")
+                .arg("-v")
+                .arg(&*format!("{}/", app.to_str().unwrap()))
+                .arg(&*format!("{}:{}/", user_at_host, &*target_path))
+                .status()?
+        };
         if !stat.success() {
             Err("error installing app")?
         }
@@ -70,18 +92,20 @@ impl Device for SshDevice {
         let user_at_host = format!("{}@{}", self.config.username, self.config.hostname);
         let prefix = self.config.path.clone().unwrap_or("/tmp".into());
         let app_name = app_path.file_name().unwrap();
-        let path = path::PathBuf::from(prefix)
-            .join("dinghy")
-            .join(app_name);
-        let stat = process::Command::new("ssh")
-            .arg(user_at_host)
-            .arg("-p")
-            .arg(&*format!("{}", self.config.port.unwrap_or(22)))
-            .arg(&*format!(
-                "rm -rf {}",
-                &path.to_str().unwrap()
-            ))
-            .status()?;
+        let path = path::PathBuf::from(prefix).join("dinghy").join(app_name);
+        let stat = if let Some(port) = self.config.port {
+            process::Command::new("ssh")
+                .arg(user_at_host)
+                .arg("-p")
+                .arg(&*format!("{}", port))
+                .arg(&*format!("rm -rf {}", &path.to_str().unwrap()))
+                .status()?
+        } else {
+            process::Command::new("ssh")
+                .arg(user_at_host)
+                .arg(&*format!("rm -rf {}", &path.to_str().unwrap()))
+                .status()?
+        };
         if !stat.success() {
             Err("test fail.")?
         }
@@ -91,21 +115,31 @@ impl Device for SshDevice {
         let user_at_host = format!("{}@{}", self.config.username, self.config.hostname);
         let prefix = self.config.path.clone().unwrap_or("/tmp".into());
         let app_name = app_path.file_name().unwrap();
-        let path = path::PathBuf::from(prefix)
-            .join("dinghy")
-            .join(app_name);
+        let path = path::PathBuf::from(prefix).join("dinghy").join(app_name);
         let exe = path.join(&app_name);
-        let stat = process::Command::new("ssh")
-            .arg(user_at_host)
-            .arg("-p")
-            .arg(&*format!("{}", self.config.port.unwrap_or(22)))
-            .arg(&*format!(
-                "DINGHY=1 {} {}",
-                envs.join(" "),
-                &exe.to_str().unwrap()
-            ))
-            .args(args)
-            .status()?;
+        let stat = if let Some(port) = self.config.port {
+            process::Command::new("ssh")
+                .arg(user_at_host)
+                .arg("-p")
+                .arg(&*format!("{}", port))
+                .arg(&*format!(
+                    "DINGHY=1 {} {}",
+                    envs.join(" "),
+                    &exe.to_str().unwrap()
+                ))
+                .args(args)
+                .status()?
+        } else {
+            process::Command::new("ssh")
+                .arg(user_at_host)
+                .arg(&*format!(
+                    "DINGHY=1 {} {}",
+                    envs.join(" "),
+                    &exe.to_str().unwrap()
+                ))
+                .args(args)
+                .status()?
+        };
         if !stat.success() {
             Err("test fail.")?
         }

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,10 +1,10 @@
 use std::{path, process};
 use errors::*;
-use ::{Device, PlatformManager};
+use {Device, PlatformManager};
 
 use config::SshDeviceConfiguration;
 
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub struct SshDevice {
     id: String,
     config: SshDeviceConfiguration,
@@ -28,12 +28,36 @@ impl Device for SshDevice {
     }
     fn install_app(&self, app: &path::Path) -> Result<()> {
         let user_at_host = format!("{}@{}", self.config.username, self.config.hostname);
-        let _stat = process::Command::new("ssh").args(&[&*user_at_host, "mkdir", "-p", "/tmp/dinghy"])
+        let prefix = self.config.path.clone().unwrap_or("/tmp".into());
+        let _stat = process::Command::new("ssh")
+            .args(
+                &[
+                    &*user_at_host,
+                    "-p",
+                    &*format!("{}", self.config.port.unwrap_or(22)),
+                    "mkdir",
+                    "-p",
+                    &*format!("{}/dinghy", prefix),
+                ],
+            )
             .status();
-        let target_path = format!("/tmp/dinghy/{}", app.file_name().unwrap().to_str().unwrap());
+        let target_path = format!(
+            "{}/dinghy/{}",
+            prefix,
+            app.file_name().unwrap().to_str().unwrap()
+        );
         info!("Rsyncing to {}", self.name());
-        println!("{}/ {}:{}/", app.to_str().unwrap(), user_at_host, &*target_path);
-        let stat = process::Command::new("/usr/bin/rsync").arg("-a").arg("-v")
+        println!(
+            "{}/ {}:{}/",
+            app.to_str().unwrap(),
+            user_at_host,
+            &*target_path
+        );
+        let stat = process::Command::new("/usr/bin/rsync")
+            .arg("-a")
+            .arg("-v")
+            .arg("-e")
+            .arg(&*format!("ssh -p {}", self.config.port.unwrap_or(22)))
             .arg(&*format!("{}/", app.to_str().unwrap()))
             .arg(&*format!("{}:{}/", user_at_host, &*target_path))
             .status()?;
@@ -42,16 +66,44 @@ impl Device for SshDevice {
         }
         Ok(())
     }
-    fn clean_app(&self, _exe: &path::Path) -> Result<()> {
-        unimplemented!()
+    fn clean_app(&self, app_path: &path::Path) -> Result<()> {
+        let user_at_host = format!("{}@{}", self.config.username, self.config.hostname);
+        let prefix = self.config.path.clone().unwrap_or("/tmp".into());
+        let app_name = app_path.file_name().unwrap();
+        let path = path::PathBuf::from(prefix)
+            .join("dinghy")
+            .join(app_name);
+        let stat = process::Command::new("ssh")
+            .arg(user_at_host)
+            .arg("-p")
+            .arg(&*format!("{}", self.config.port.unwrap_or(22)))
+            .arg(&*format!(
+                "rm -rf {}",
+                &path.to_str().unwrap()
+            ))
+            .status()?;
+        if !stat.success() {
+            Err("test fail.")?
+        }
+        Ok(())
     }
     fn run_app(&self, app_path: &path::Path, args: &[&str], envs: &[&str]) -> Result<()> {
         let user_at_host = format!("{}@{}", self.config.username, self.config.hostname);
+        let prefix = self.config.path.clone().unwrap_or("/tmp".into());
         let app_name = app_path.file_name().unwrap();
-        let path = path::PathBuf::from("/tmp/dinghy").join(app_name);
+        let path = path::PathBuf::from(prefix)
+            .join("dinghy")
+            .join(app_name);
         let exe = path.join(&app_name);
-        let stat = process::Command::new("ssh").arg(user_at_host)
-            .arg(&*format!("DINGHY=1 {} {}", envs.join(" "), &exe.to_str().unwrap()))
+        let stat = process::Command::new("ssh")
+            .arg(user_at_host)
+            .arg("-p")
+            .arg(&*format!("{}", self.config.port.unwrap_or(22)))
+            .arg(&*format!(
+                "DINGHY=1 {} {}",
+                envs.join(" "),
+                &exe.to_str().unwrap()
+            ))
             .args(args)
             .status()?;
         if !stat.success() {
@@ -64,8 +116,7 @@ impl Device for SshDevice {
     }
 }
 
-pub struct SshDeviceManager {
-}
+pub struct SshDeviceManager {}
 
 impl SshDeviceManager {
     pub fn probe() -> Option<SshDeviceManager> {
@@ -75,15 +126,17 @@ impl SshDeviceManager {
 
 impl PlatformManager for SshDeviceManager {
     fn devices(&self) -> Result<Vec<Box<Device>>> {
-        Ok(::config::config(::std::env::current_dir().unwrap())?
-            .ssh_devices
-            .iter()
-            .map(|(k, d)| {
-                Box::new(SshDevice {
-                    id: k.clone(),
-                    config: d.clone(),
-                }) as _
-            })
-            .collect())
+        Ok(
+            ::config::config(::std::env::current_dir().unwrap())?
+                .ssh_devices
+                .iter()
+                .map(|(k, d)| {
+                    Box::new(SshDevice {
+                        id: k.clone(),
+                        config: d.clone(),
+                    }) as _
+                })
+                .collect(),
+        )
     }
 }


### PR DESCRIPTION
Some fixes and improvements for ssh mode:

- Implement clean_app
- Allow port to be overridden #26 
- Allow path to be overridden