### PR TITLE
Update build_env.rs

### DIFF
--- a/dinghy-build/src/build_env.rs
+++ b/dinghy-build/src/build_env.rs
@@ -17,6 +17,7 @@ use std::env;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::path::PathBuf;
+use std::ascii::AsciiExt;
 use super::Result;
 use super::ResultExt;
 


### PR DESCRIPTION
Line 61 fails due to `c.to_ascii_uppercase` which requires `use std::ascii::AsciiExt;`