### PR TITLE
Fix multiple versions of the same dynamic lib used

### DIFF
--- a/dinghy-lib/src/compiler.rs
+++ b/dinghy-lib/src/compiler.rs
@@ -25,6 +25,7 @@ use Runnable;
 use std::collections::HashSet;
 use std::env;
 use std::env::current_dir;
+use std::ffi::OsString;
 use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
@@ -489,6 +490,15 @@ fn find_dynamic_libraries(compilation: &Compilation,
         .filter_map(|walk_entry| walk_entry.map(|it| it.path().to_path_buf()).ok())
         .filter(|path| is_library(path) && is_library_linked_to_project(path))
         .filter(|path| is_banned(path))
+        .fold(Vec::new(), |mut acc : Vec<PathBuf>, x| {
+            if !acc.iter().find(|x1| x.file_name().unwrap_or(&OsString::from("")) == x1.file_name().unwrap_or(&OsString::from(""))).is_some() { //If there is not yet a copy of the lib file in the vector
+                acc.push(x);
+                acc
+            }
+            else {
+                acc
+            }
+        }).into_iter()
         .inspect(|path| debug!("Found library {}", path.display()))
         .collect())
 }


### PR DESCRIPTION
Currently, in the Android NDK r19b, there are multiple versions of the same library for different architectures. Dinghy would find the correct lib file first, but then would search for more lib files and find the files for incorrect architectures. It led to some strange behaviors where Dinghy would try to run a 64 bit ARM binary with a 32 bit Intel dynamic library.

This fix applies a filter on the library file path list by taking the first occurrence of a library file and discard the rest of the occurrences. Therefore, there is only one version of each lib in the list, most likely the fitting one.