### PR TITLE
Android ndk 19+ API level choice

### DIFF
--- a/cargo-dinghy/src/main.rs
+++ b/cargo-dinghy/src/main.rs
@@ -158,7 +158,9 @@ fn show_all_devices(dinghy: &Dinghy) -> Result<()> {
 }
 
 fn show_all_platforms(dinghy: &Dinghy) -> Result<()> {
-    for pf in dinghy.platforms() {
+    let mut platforms = dinghy.platforms();
+    platforms.sort_by(|str1, str2| str1.id().cmp(&str2.id()));
+    for pf in platforms.iter() {
         println!("* {} {}", pf.id(), pf.rustc_triple().map(|s| format!("({})", s)).unwrap_or("".to_string()));
     }
     Ok(())


### PR DESCRIPTION
Previously, the `auto-android-[ARCHITECTURE]` platform was building for the latest API level (28).

Now, there are more platforms available : one platform per API level available. Each android auto platform are now using the following naming convention : `auto-android-[ARCHITECTURE]-api[API_LEVEL]`.

The `all-platforms` subcommand output was modified to output the available platforms in alphabetical order for aesthetic purposes.