### PR TITLE
Make automatic platform decision for a given device deterministic

### DIFF
--- a/cargo-dinghy/src/main.rs
+++ b/cargo-dinghy/src/main.rs
@@ -202,6 +202,11 @@ fn select_platform_and_device_from_cli(matches: &ArgMatches,
 
         Ok((platform, device))
     } else if let Some(device_filter) = matches.value_of("DEVICE") {
+        let is_banned_auto_platform_id = |id: &str| -> bool {
+            id.contains("auto-android") && (id.contains("min")
+                                    || id.contains("latest")
+                                    || id.contains("api"))
+        };
         let devices = dinghy.devices()
             .into_iter()
             .filter(move |it| format!("{:?}", it).to_lowercase().contains(&device_filter.to_lowercase()))
@@ -221,8 +226,4 @@ fn select_platform_and_device_from_cli(matches: &ArgMatches,
     }
 }
 
-fn is_banned_auto_platform_id(id: &str) -> bool {
-    id.contains("auto-android") && (id.contains("min")
-                                    || id.contains("latest")
-                                    || id.contains("api"))
-}
+

--- a/cargo-dinghy/src/main.rs
+++ b/cargo-dinghy/src/main.rs
@@ -210,7 +210,7 @@ fn select_platform_and_device_from_cli(matches: &ArgMatches,
             Err(format!("No devices found for name hint `{}'", device_filter))?;
         }
         devices.into_iter().filter_map(|d| {
-            let pf = dinghy.platforms().iter().find(|pf| pf.is_compatible_with(&**d)).cloned();
+            let pf = dinghy.platforms().iter().filter(|pf| !is_banned_auto_platform_id(&pf.id())).find(|pf| pf.is_compatible_with(&**d)).cloned();
             debug!("Looking for platform for {}: found {:?}", d.id(), pf.as_ref().map(|p| p.id()));
             pf.map(|it| (it,Some(d)))
         })
@@ -219,4 +219,10 @@ fn select_platform_and_device_from_cli(matches: &ArgMatches,
     } else {
         Ok((dinghy.host_platform(), Some(dinghy.host_device())))
     }
+}
+
+fn is_banned_auto_platform_id(id: &str) -> bool {
+    id.contains("auto-android") && (id.contains("min")
+                                    || id.contains("latest")
+                                    || id.contains("api"))
 }

--- a/cargo-dinghy/src/main.rs
+++ b/cargo-dinghy/src/main.rs
@@ -225,5 +225,3 @@ fn select_platform_and_device_from_cli(matches: &ArgMatches,
         Ok((dinghy.host_platform(), Some(dinghy.host_device())))
     }
 }
-
-


### PR DESCRIPTION
Previously, running the `-d` argument for an android device without explicitly defining the platform would randomly take a platform with the fitting architecture but with a certain API level which was a semi-random choice of all available API levels.

Now, the choice will be to take the default API level of the device architecture, which is currently pointing to API level 21 for all architectures. The user can still specify a particular API using the `--platform` argument which works with `-d`.