### PR TITLE
Change IosSimDevice to use xcrun simctl launch rather than lldb

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -54,6 +54,31 @@ echo "##"
 echo "## latest failure was expected ##"
 echo "##"
 
+# Test ios-simulator.
+export SIM_ID=$(xcrun simctl create My-iphone7 com.apple.CoreSimulator.SimDeviceType.iPhone-7 com.apple.CoreSimulator.SimRuntime.iOS-13-2)
+xcrun simctl boot $SIM_ID
+# Test from workspace root with project filter
+( \
+    cd test-ws \
+    && cargo clean \
+    && $CARGO_DINGHY -d $SIM_ID test -p test-app pass \
+    && ! $CARGO_DINGHY -d $SIM_ID test -p test-app fails \
+)
+echo "##"
+echo "## latest failure was expected ##"
+echo "##"
+
+# Test in project subdir
+( \
+    cd test-ws/test-app \
+    && cargo clean \
+    && $CARGO_DINGHY -d $SIM_ID test pass \
+    && ! $CARGO_DINGHY -d $SIM_ID test fails \
+)
+echo "##"
+echo "## latest failure was expected ##"
+echo "##"
+
 if [ -n "$DEPLOY" ]
 then
     if [ `uname` = Linux ]

--- a/.travis.sh
+++ b/.travis.sh
@@ -55,7 +55,8 @@ echo "## latest failure was expected ##"
 echo "##"
 
 # Test on the ios-simulator.
-if [ "$TRAVIS_OS_NAME" = osx ]; then
+if [ `uname` = Darwin ]
+then
     rustup target add x86_64-apple-ios;
     export SIM_ID=$(xcrun simctl create My-iphone7 com.apple.CoreSimulator.SimDeviceType.iPhone-7 com.apple.CoreSimulator.SimRuntime.iOS-13-2)
     xcrun simctl boot $SIM_ID

--- a/.travis.sh
+++ b/.travis.sh
@@ -54,30 +54,33 @@ echo "##"
 echo "## latest failure was expected ##"
 echo "##"
 
-# Test ios-simulator.
-export SIM_ID=$(xcrun simctl create My-iphone7 com.apple.CoreSimulator.SimDeviceType.iPhone-7 com.apple.CoreSimulator.SimRuntime.iOS-13-2)
-xcrun simctl boot $SIM_ID
-# Test from workspace root with project filter
-( \
-    cd test-ws \
-    && cargo clean \
-    && $CARGO_DINGHY -d $SIM_ID test -p test-app pass \
-    && ! $CARGO_DINGHY -d $SIM_ID test -p test-app fails \
-)
-echo "##"
-echo "## latest failure was expected ##"
-echo "##"
+# Test on the ios-simulator.
+if [ "$TRAVIS_OS_NAME" = osx ]; then
+    rustup target add x86_64-apple-ios;
+    export SIM_ID=$(xcrun simctl create My-iphone7 com.apple.CoreSimulator.SimDeviceType.iPhone-7 com.apple.CoreSimulator.SimRuntime.iOS-13-2)
+    xcrun simctl boot $SIM_ID
+    # Test from workspace root with project filter
+    ( \
+        cd test-ws \
+        && cargo clean \
+        && $CARGO_DINGHY -d $SIM_ID test -p test-app pass \
+        && ! $CARGO_DINGHY -d $SIM_ID test -p test-app fails \
+    )
+    echo "##"
+    echo "## latest failure was expected ##"
+    echo "##"
 
-# Test in project subdir
-( \
-    cd test-ws/test-app \
-    && cargo clean \
-    && $CARGO_DINGHY -d $SIM_ID test pass \
-    && ! $CARGO_DINGHY -d $SIM_ID test fails \
-)
-echo "##"
-echo "## latest failure was expected ##"
-echo "##"
+    # Test in project subdir
+    ( \
+        cd test-ws/test-app \
+        && cargo clean \
+        && $CARGO_DINGHY -d $SIM_ID test pass \
+        && ! $CARGO_DINGHY -d $SIM_ID test fails \
+    )
+    echo "##"
+    echo "## latest failure was expected ##"
+    echo "##"
+fi
 
 if [ -n "$DEPLOY" ]
 then

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   - rust: nightly
   include:
   - os: osx
-    osx_image: xcode9.3
+    osx_image: xcode11.2
     env: DEPLOY=macos
   - os: linux
     dist: bionic

--- a/dinghy-lib/src/errors.rs
+++ b/dinghy-lib/src/errors.rs
@@ -3,6 +3,7 @@ error_chain! {
     foreign_links {
         Io(::std::io::Error);
         StringFromUtf8(::std::string::FromUtf8Error);
+        ParseIntError(std::num::ParseIntError);
         PathStripPrefix(::std::path::StripPrefixError);
         Plist(::plist::Error);
         Regex(::regex::Error);

--- a/dinghy-lib/src/errors.rs
+++ b/dinghy-lib/src/errors.rs
@@ -3,7 +3,7 @@ error_chain! {
     foreign_links {
         Io(::std::io::Error);
         StringFromUtf8(::std::string::FromUtf8Error);
-        ParseIntError(std::num::ParseIntError);
+        ParseInt(::std::num::ParseIntError);
         PathStripPrefix(::std::path::StripPrefixError);
         Plist(::plist::Error);
         Regex(::regex::Error);

--- a/dinghy-lib/src/ios/device.rs
+++ b/dinghy-lib/src/ios/device.rs
@@ -665,7 +665,7 @@ fn launch_app(
     dev: &IosSimDevice,
     app_args: &[&str]
 ) -> Result<()> {
-    use std::io::{Read, Write};
+    use std::io::Write;
     let dir = ::tempdir::TempDir::new("mobiledevice-rs-lldb")?;
     let tmppath = dir.path();
     let mut install_path = String::from_utf8(
@@ -706,10 +706,7 @@ fn launch_app(
         .arg("-s")
         .arg(lldb_script_filename)
         .output()?;
-
-    let mut file = std::fs::File::open(stdout)?;
-    let mut test_contents = String::new();
-    file.read_to_string(&mut test_contents)?;
+    let test_contents = std::fs::read_to_string(stdout)?;
     println!("{}", test_contents);
 
     let output : String = String::from_utf8_lossy(&output.stdout).to_string();

--- a/dinghy-lib/src/ios/device.rs
+++ b/dinghy-lib/src/ios/device.rs
@@ -245,13 +245,7 @@ impl Device for IosSimDevice {
         let mut build_bundles = vec![];
         for runnable in &build.runnables {
             let build_bundle = self.install_app(&project, &build, &runnable)?;
-            let install_path = String::from_utf8(
-                process::Command::new("xcrun")
-                    .args(&["simctl", "get_app_container", &self.id, "Dinghy"])
-                    .output()?
-                    .stdout,
-            )?;
-            launch_lldb_simulator(&self, &install_path, args, false)?;
+            launch_app(&self, args)?;
             build_bundles.push(build_bundle);
         }
         Ok(build_bundles)
@@ -665,6 +659,22 @@ fn launch_lldb_device<P: AsRef<Path>, P2: AsRef<Path>>(
     } else {
         Err(format!("LLDB returned error code {:?}", stat.code()))?
     }
+}
+
+fn launch_app(
+    dev: &IosSimDevice,
+    app_args: &[&str]
+) -> Result<()> {
+    let mut xcrun_args : Vec<&str> = vec![
+              "simctl",
+              "launch",
+              "--console-pyt",
+              &dev.id,
+              "Dinghy",
+    ];
+    xcrun_args.extend(app_args);
+    process::Command::new("xcrun").args(&xcrun_args).spawn()?.wait()?;
+    Ok(())
 }
 
 fn launch_lldb_simulator(

--- a/dinghy-lib/src/ios/device.rs
+++ b/dinghy-lib/src/ios/device.rs
@@ -661,7 +661,6 @@ fn launch_lldb_device<P: AsRef<Path>, P2: AsRef<Path>>(
     }
 }
 
-
 fn launch_app(
     dev: &IosSimDevice,
     app_args: &[&str]
@@ -754,7 +753,6 @@ fn launch_app(
     } else {
         panic!("Failed to get the exit status line from lldb: {:?}", lines);
     }
-
 }
 
 fn launch_lldb_simulator(

--- a/dinghy-lib/src/ios/device.rs
+++ b/dinghy-lib/src/ios/device.rs
@@ -692,7 +692,7 @@ fn launch_app(
     let launch_output = process::Command::new("xcrun").args(&xcrun_args).output()?;
     let launch_output = String::from_utf8_lossy(&launch_output.stdout);
 
-    // Output from the launch command should be "Dinghy: $PID" which is 8 characters.
+    // Output from the launch command should be "Dinghy: $PID" which is after the 8th character.
     let dinghy_pid = launch_output.split_at(8).1;
 
     // Attaching to the processes needs to be done in a script, not a commandline parameter or
@@ -700,7 +700,6 @@ fn launch_app(
     let lldb_script_filename = tmppath.join("lldb-script");
     let mut script = fs::File::create(&lldb_script_filename)?;
     write!(script, "attach {}\n", dinghy_pid)?;
-    //write!(script, "attach --name {}/Dinghy\n", install_path)?;
     write!(script, "continue\n")?;
     write!(script, "quit\n")?;
     let output = process::Command::new("lldb")
@@ -716,7 +715,7 @@ fn launch_app(
 
     let output : String = String::from_utf8_lossy(&output.stdout).to_string();
     debug!("LLDB OUTPUT: {}", output);
-    // The output from lldb is something like:
+    // The stdout from lldb is something like:
     //
     // (lldb) attach 34163
     // Process 34163 stopped

--- a/dinghy-lib/src/ios/xcode.rs
+++ b/dinghy-lib/src/ios/xcode.rs
@@ -21,6 +21,10 @@ pub fn add_plist_to_app(bundle: &BuildBundle, arch: &str, app_bundle_id: &str) -
     )?;
     writeln!(plist, "<key>UIRequiredDeviceCapabilities</key>")?;
     writeln!(plist, "<array><string>{}</string></array>", arch)?;
+    writeln!(plist, "<key>CFBundleVersion</key>")?;
+    writeln!(plist, "<string>{}</string>", arch)?;
+    writeln!(plist, "<key>CFBundleShortVersionString</key>")?;
+    writeln!(plist, "<string>{}</string>", arch)?;
     writeln!(plist, r#"</dict></plist>"#)?;
     /*
     let app_name = app_bundle_id.split(".").last().unwrap();

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -12,7 +12,7 @@ cargo install cargo-dinghy
 cargo install cargo-dinghy --force
 ```
 
-### iOS phone 
+### iOS phone
 
 On iOS, things are made complicated by the fact that there is no way to run a
 naked executable on a device: you need to make it an app, and sign it before
@@ -26,7 +26,7 @@ Again, we don't need a paying account.
 ### Creating a signing id
 
 You may skip most of this section if you're already setup to ship code to
-your phone. 
+your phone.
 
 * You'll need an Apple ID. Chances are you already have one, but you can
     an account there: https://appleid.apple.com/account .
@@ -62,7 +62,7 @@ longer living certificates, so you need this less often.
 
 On top of project window, make the target "Dinghy>Your Device", and run the
 project (play button). XCode may ask you to go to your phone settings
-and Trust the certificate. It's in the Preferences > General > 
+and Trust the certificate. It's in the Preferences > General >
 [your dev account name]. It should then start your empty app on the phone.
 
 At this point, we're ready to roll, dinghy should detect XCode and the various
@@ -87,18 +87,21 @@ name are supposed to pass, the one with fail should break.
 
 ### Simulator
 
-The simulator support is broken by the current version of XCode. It is know to
-work with XCode 8 though.
+There's a [known bug with lldb and the ios
+simulator](https://bugs.llvm.org/show_bug.cgi?id=36580) as such, dinghy will
+use lldb to attach to the process on macOS to get the exit status from the
+simulator.  On Catalina (and probably earlier), this means the user will be
+prompted for higher permissions.
 
 ### Debugging tips
 
-If you got lost somewhere, here are a few hints to help you make sense of 
+If you got lost somewhere, here are a few hints to help you make sense of
 what is happening. This is more or less what Dinghy use when fishing for
 your signing identity.
 
 #### `security find-identity -p codesigning`
 
-Shows you the codesigning identities available where you are. You should see 
+Shows you the codesigning identities available where you are. You should see
 one or more identities line, made of a long capitalize hex identifier, followed
 by a "name". The name is very structured: For iOS development , its starts
 with the string "iPhone Developer: ", followed by an email (for an Apple Id
@@ -123,7 +126,7 @@ chosen while creating the project) on one (or more) devices.
 
 These certificates are in `Library/MobileDevice/Provisioning\ Profiles`.
 
-To read them, you'll need to do 
+To read them, you'll need to do
 
 ```
 security cms -D -i  ~/Library/MobileDevice/Provisioning\ Profiles\....mobileprovision


### PR DESCRIPTION
Given that https://bugs.llvm.org/show_bug.cgi?id=36580 seems to be a bug in lldb, I figure it's worth having a work around using `xcrun simctl launch`

I've spent a bunch of time trying to get the exit status of the app to actually propagate but I'm not sure 
how to make `simctl` do it. I don't have a machine with Xcode 8 to see if it propagated before but, I think it's a step forward to just have the test outputs running and being displayed.

Sample output:

```
$ cargo dinghy --platform auto-ios-x86_64 test
 INFO  cargo_dinghy > Targeting platform 'auto-ios-x86_64' and device '078869FD-7B1E-4BB2-AE23-8FBDDF952715'
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
Dinghy: 19151

running 4 tests
test tests::pass::it_works ... ok
test tests::fails::it_fails ... FAILED
test tests::pass::it_finds_source_files ... ok
test tests::pass::it_finds_test_data_files ... ok

failures:

---- tests::fails::it_fails stdout ----
thread 'tests::fails::it_fails' panicked at 'Failing as expected', test-app/src/lib.rs:56:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.


failures:
    tests::fails::it_fails

test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

You'll notice `Dinghy: 19151` is in the output. To remove that would need to use a tempfile and just redirect stdout to it. Really not a hard change but I just didn't feel like adding a new dependency.

Thoughts?