### PR TITLE
add upload rsync binary step for the ssh devices

### DIFF
--- a/dinghy-lib/src/config.rs
+++ b/dinghy-lib/src/config.rs
@@ -140,6 +140,7 @@ pub struct SshDeviceConfiguration {
     pub username: String,
     pub port: Option<u16>,
     pub path: Option<String>,
+    pub rsync: Option<String>,
     pub target: Option<String>,
     pub toolchain: Option<String>,
     pub platform: Option<String>,

--- a/dinghy-lib/src/config.rs
+++ b/dinghy-lib/src/config.rs
@@ -140,10 +140,10 @@ pub struct SshDeviceConfiguration {
     pub username: String,
     pub port: Option<u16>,
     pub path: Option<String>,
-    pub rsync: Option<String>,
     pub target: Option<String>,
     pub toolchain: Option<String>,
     pub platform: Option<String>,
+    pub install_adhoc_rsync_local_path: Option<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/dinghy-lib/src/ssh/device.rs
+++ b/dinghy-lib/src/ssh/device.rs
@@ -64,6 +64,7 @@ impl SshDevice {
             Some(rsync) => {
                 let rsync_path = "/tmp/rsync";
                 let mut command = Command::new("scp");
+                command.arg("-q");
                 command.arg(format!("{}", rsync));
                 command.arg(format!(
                     "{}@{}:{}",
@@ -83,7 +84,7 @@ impl SshDevice {
     }
 
     fn sync<FP: AsRef<Path>, TP: AsRef<Path>>(&self, from_path: FP, to_path: TP) -> Result<()> {
-        let rsync = self.sync_rsync(self.conf.rsync.clone());
+        let rsync = self.sync_rsync(self.conf.install_adhoc_rsync_local_path.clone());
         let rsync = match rsync {
             Ok(rsync_path) => rsync_path,
             Err(error) => bail!("Problem with rsync on the target: {:?}", error),


### PR DESCRIPTION
on some ssh devices `rsync` is not necessarily installed.

this allow the upload of a pre-build `rsync` binary on the target ssh device, useful if `/usr/bin/rsync` does not exists on the target, this is done by adding `install_adhoc_rsync_local_path` in the `dinghy.toml`:

```
[platforms.rsync-test]
rustc_triple='aarch64-unknown-linux-gnu'
toolchain='/home/treym//toolchains/rsync-test/aarch64-unknown-linux-gnu'

[ssh_devices]
ci-rsync-test-001 = { hostname = "192.168.1.34", username="test", platform="rsync-test", install_adhoc_rsync_local_path="/home/treym/toolchains/rsync-test/prebuilt/bin/rsync" }
```
