### PR TITLE
experimental shell expansion in run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shellexpand 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1125,6 +1126,14 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "shellexpand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sized-chunks"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,6 +1506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_ignored 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7248fdcbd17d3f2604fc2a02d0ecc844d9a7bf52bf95fc196d9f0a38f6da6a0e"
 "checksum serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)" = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
 "checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
+"checksum shellexpand 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2b22262a9aaf9464d356f656fea420634f78c881c5eebd5ef5e66d8b9bc603"
 "checksum sized-chunks 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d59044ea371ad781ff976f7b06480b9f0180e834eda94114f2afb4afc12b7718"
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum socket2 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"

--- a/dinghy-lib/Cargo.toml
+++ b/dinghy-lib/Cargo.toml
@@ -36,6 +36,7 @@ toml = "0.5"
 shell-escape = "0.1"
 walkdir = "2.0"
 which = "3.0"
+shellexpand="2"
 url = "= 2.1.1" # The `url` version 2.1.1 introduced a regression in Cargo (https://github.com/servo/rust-url/issues/577). This line should be removed once `cargo` lib is updated to support ssh urls again. It should be included in `cargo` 0.43: https://github.com/rust-lang/cargo/pull/7787/commits/dde27346685e09166967616581aac383918b2c04#diff-1dc41e0ad8fa6e5cafa93ac2d22c67f3
 
 [target.'cfg(target_os="macos")'.dependencies]

--- a/dinghy-lib/src/compiler.rs
+++ b/dinghy-lib/src/compiler.rs
@@ -69,9 +69,10 @@ impl Compiler {
         &self,
         rustc_triple: Option<&str>,
         build_args: &BuildArgs,
-        args: &[&str],
+        args: &[impl AsRef<str>],
     ) -> Result<()> {
-        (self.run_command)(rustc_triple, build_args, args)
+        let args = args.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+        (self.run_command)(rustc_triple, build_args, &*args)
     }
 }
 

--- a/dinghy-lib/src/config.rs
+++ b/dinghy-lib/src/config.rs
@@ -143,6 +143,8 @@ pub struct SshDeviceConfiguration {
     pub target: Option<String>,
     pub toolchain: Option<String>,
     pub platform: Option<String>,
+    #[serde(default)]
+    pub remote_shell_vars: collections::HashMap<String, String>,
     pub install_adhoc_rsync_local_path: Option<String>,
 }
 

--- a/dinghy-lib/src/host/device.rs
+++ b/dinghy-lib/src/host/device.rs
@@ -81,7 +81,12 @@ impl Device for HostDevice {
             set_env(env_key, env_value);
         }
         let build_bundles = self.install_all_apps(project, build)?;
-        self.compiler.run(None, &build.build_args, args)?;
+        let args = args
+            .iter()
+            .map(|arg| Ok(shellexpand::full(arg)?.to_string()))
+            .collect::<Result<Vec<_>>>()?;
+        debug!("Arguments expanded to: {:?}", args);
+        self.compiler.run(None, &build.build_args, &*args)?;
         Ok(build_bundles)
     }
 


### PR DESCRIPTION
Add shell expansion to run command arguments. For instance, in dinghy.toml:

```
[ssh_devices]
raspi = { hostname = "raspi-kali.local", username="pi", platform="raspbian-stretch", remote_shell_vars= { HOME="/home/pi/" } }
raspi3u64 = { hostname = "raspi-kali-home-u64.local", username="ubuntu", platform="aarch64-unknown-linux-gnu", remote_shell_vars= { HOME="/home/ubuntu/" } }
```

then I can get ~ (and ENVIRONMENT_VARIABLES) expanded using the proficed config (or the local envir if targetting HOST). This allow to manage some heavy test resources by hand instead of using dinghy synchro.

```
cargo-dinghy -v -d pi3u64 run --release --no-default-features --features onnx -- "~/.cache/en_libri_real/model.onnx" -i Sx40xf32 --output-node output --pulse 24 -O -vvv dump --cost --profile
```

Note that we need to escape the path argument with "" to avoid the local shell expansion (which heppen before the argument is handed to dinghy). This breaks compatibility between "cargo run" and "cargo dinghy run"...