### PR TITLE
iOS environment variable support

### DIFF
--- a/dinghy-lib/src/ios/device.rs
+++ b/dinghy-lib/src/ios/device.rs
@@ -800,7 +800,7 @@ fn launch_lldb_simulator(
     dev: &IosSimDevice,
     installed: &str,
     args: &[&str],
-    _envs: &[&str],
+    envs: &[&str],
     debugger: bool,
 ) -> Result<()> {
     use std::io::Write;

--- a/dinghy-lib/src/ios/device.rs
+++ b/dinghy-lib/src/ios/device.rs
@@ -810,7 +810,9 @@ fn launch_lldb_simulator(
     let lldb_script_filename = tmppath.join("lldb-script");
     {
         let python_lldb_support = tmppath.join("helpers.py");
-        fs::File::create(&python_lldb_support)?.write_all(include_bytes!("helpers.py"))?;
+        let helper_py = include_str!("helpers.py");
+        let helper_py = helper_py.replace("ENV_VAR_PLACEHOLDER", &envs.join("\", \""));
+        fs::File::create(&python_lldb_support)?.write_fmt(format_args!("{}", &helper_py))?;
         let mut script = fs::File::create(&lldb_script_filename)?;
         writeln!(script, "platform select ios-simulator")?;
         writeln!(script, "target create {}", installed)?;

--- a/dinghy-lib/src/ios/device.rs
+++ b/dinghy-lib/src/ios/device.rs
@@ -57,8 +57,8 @@ impl IosDevice {
             x => bail!("DeviceName should have been a string, was {:?}", x),
         };
         let cpu = match device_read_value(ptr, "CPUArchitecture")? {
-            Some(Value::String(ref v)) if v == "arm64" => "aarch64",
-            _ => "armv7",
+            Some(Value::String(ref v)) if v == "arm64" || v == "arm64e" => "aarch64",
+            v => "armv7",
         };
         let id = if let Value::String(id) = rustify(unsafe { AMDeviceCopyDeviceIdentifier(ptr) })? {
             id

--- a/dinghy-lib/src/ios/helpers.py
+++ b/dinghy-lib/src/ios/helpers.py
@@ -14,7 +14,9 @@ def set_remote_path(debugger, command, result, internal_dict):
 
 def start(debugger, command, result, internal_dict):
     error = lldb.SBError()
-    proc = lldb.target.Launch(lldb.SBLaunchInfo(shlex.split(command)), error)
+    info = lldb.SBLaunchInfo(shlex.split(command))
+    info.SetEnvironmentEntries(["METAL_DEVICE_WRAPPER_TYPE=1", "METAL_DEBUG_ERROR_MODE=0"], True)
+    proc = lldb.target.Launch(info, error)
     lockedstr = ': Locked'
     if proc.GetState() != lldb.eStateExited:
         print("process left in lldb state: %s"%(debugger.StateAsCString(proc.GetState())))
@@ -22,7 +24,7 @@ def start(debugger, command, result, internal_dict):
         print('\nDevice Locked\n')
         os._exit(254)
     elif proc.GetState() == lldb.eStateStopped:
-        thread = proc.GetSelectedThread();
+        thread = proc.GetSelectedThread()
         print(thread)
         for frame in thread:
             print("  %s"%(frame))

--- a/dinghy-lib/src/ios/helpers.py
+++ b/dinghy-lib/src/ios/helpers.py
@@ -15,7 +15,7 @@ def set_remote_path(debugger, command, result, internal_dict):
 def start(debugger, command, result, internal_dict):
     error = lldb.SBError()
     info = lldb.SBLaunchInfo(shlex.split(command))
-    info.SetEnvironmentEntries(["METAL_DEVICE_WRAPPER_TYPE=1", "METAL_DEBUG_ERROR_MODE=0"], True)
+    info.SetEnvironmentEntries(["ENV_VAR_PLACEHOLDER"], True)
     proc = lldb.target.Launch(info, error)
     lockedstr = ': Locked'
     if proc.GetState() != lldb.eStateExited:

--- a/dinghy-lib/src/ssh/device.rs
+++ b/dinghy-lib/src/ssh/device.rs
@@ -1,6 +1,7 @@
 use crate::config::SshDeviceConfiguration;
 use crate::device::make_remote_app;
 use crate::errors::*;
+use crate::host::HostPlatform;
 use crate::platform::regular_platform::RegularPlatform;
 use crate::project::Project;
 use crate::utils::path_to_str;
@@ -15,7 +16,6 @@ use std::fmt::{Debug, Display};
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
-use crate::host::HostPlatform;
 
 pub struct SshDevice {
     pub id: String,


### PR DESCRIPTION
This is quite hacky; but it enables the metal debug layer (by default). This same code could be used to add other environment variables.

Probably shouldn't be merged as-is.