### PR TITLE
Add automatic sysroot injection into build environment flags

### DIFF
--- a/dinghy-lib/src/config.rs
+++ b/dinghy-lib/src/config.rs
@@ -118,14 +118,31 @@ impl PlatformConfiguration {
     }
 
     pub fn env(&self) -> Vec<(String, String)> {
-        self.env
+        let mut env = self
+            .env
             .as_ref()
             .map(|it| {
                 it.iter()
                     .map(|(key, value)| (key.to_string(), value.to_string()))
                     .collect_vec()
             })
-            .unwrap_or(vec![])
+            .unwrap_or(vec![]);
+
+        if let Some(sysroot) = self.sysroot.as_ref() {
+            let flags = ["CFLAGS", "CPPFLAGS", "CXXFLAGS", "LDFLAGS"];
+
+            '_flags: for flag in flags {
+                for (key, value) in &mut env {
+                    if key == flag {
+                        value.push_str(format!(" --sysroot={sysroot}").as_str());
+                        continue '_flags;
+                    }
+                }
+                env.push((flag.to_string(), format!("--sysroot={sysroot}")));
+            }
+        }
+
+        env
     }
 }
 

--- a/dinghy-lib/src/config.rs
+++ b/dinghy-lib/src/config.rs
@@ -118,31 +118,27 @@ impl PlatformConfiguration {
     }
 
     pub fn env(&self) -> Vec<(String, String)> {
-        let mut env = self
-            .env
-            .as_ref()
-            .map(|it| {
-                it.iter()
-                    .map(|(key, value)| (key.to_string(), value.to_string()))
-                    .collect_vec()
-            })
-            .unwrap_or(vec![]);
+        let Some(env) = self.env.as_ref() else {
+            return vec![];
+        };
 
         if let Some(sysroot) = self.sysroot.as_ref() {
-            let flags = ["CFLAGS", "CPPFLAGS", "CXXFLAGS", "LDFLAGS"];
-
-            '_flags: for flag in flags {
-                for (key, value) in &mut env {
-                    if key == flag {
-                        value.push_str(format!(" --sysroot={sysroot}").as_str());
-                        continue '_flags;
-                    }
-                }
-                env.push((flag.to_string(), format!("--sysroot={sysroot}")));
+            let mut env = env.clone();
+            for flag in ["CFLAGS", "CPPFLAGS", "CXXFLAGS", "LDFLAGS"] {
+                let sr_argument = format!("--sysroot={sysroot}");
+                env.entry(flag.to_string())
+                    .and_modify(|value| {
+                        value.push(' ');
+                        value.push_str(&sr_argument);
+                    })
+                    .or_insert(sr_argument);
             }
+            env.into_iter().collect_vec()
+        } else {
+            env.iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect()
         }
-
-        env
     }
 }
 


### PR DESCRIPTION
## Summary

When cross-compiling with a toolchain that requires an explicit `--sysroot` argument (such as Yocto SDK toolchains), users currently have to manually add `--sysroot=<path>` to each of `CFLAGS`, `CXXFLAGS`, `CPPFLAGS` and `LDFLAGS` in their `dinghy.toml`. 

This PR takes advantage of the existing `sysroot` field in the platform configuration to automatically append `--sysroot=<path>` to all four flag variables, covering every stage of the build.

If any of these variables are already set by the user, the `sysroot` flag is appended to the existing value. If not, the variable is created with just the `sysroot` flag.

If no `sysroot` parameter is given, environment variables are left untouched.